### PR TITLE
Adicionando validações e ajustando algumas instalações

### DIFF
--- a/Linux Mint 19.x posinstall Diolinux.sh
+++ b/Linux Mint 19.x posinstall Diolinux.sh
@@ -9,42 +9,17 @@ URL_PPA_WINE="https://dl.winehq.org/wine-builds/ubuntu/"
 URL_GOOGLE_CHROME="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
 URL_SIMPLE_NOTE="https://github.com/Automattic/simplenote-electron/releases/download/v1.8.0/Simplenote-linux-1.8.0-amd64.deb"
 URL_4K_VIDEO_DOWNLOADER="https://dl.4kdownload.com/app/4kvideodownloader_4.9.2-1_amd64.deb"
-URL_INSYNC="https://d2t3ff60b2tol4.cloudfront.net/builds/insync_3.0.20.40428-bionic_amd64.deb"
+URL_INSYNC="https://d2t3ff60b2tol4.cloudfront.net/builds/insync_3.3.0.40894-focal_amd64.deb"
 
-DIRETORIO_DOWNLOADS="$HOME/Downloads/programas"
-
-PROGRAMAS_PARA_INSTALAR=(
-  snapd
-  mint-meta-codecs
-  winff
-  guvcview
-  virtualbox
-  flameshot
-  nemo-dropbox
-  steam-installer
-  steam-devices
-  steam:i386
-  ratbagd
-  piper
-  lutris
-  libvulkan1
-  libvulkan1:i386
-  libgnutls30:i386
-  libldap-2.4-2:i386
-  libgpg-error0:i386
-  libxml2:i386
-  libasound2-plugins:i386
-  libsdl2-2.0-0:i386
-  libfreetype6:i386
-  libdbus-1-3:i386
-  libsqlite3-0:i386
-)
+DIRETORIO_DOWNLOADS="${HOME}/Downloads/programas"
 # ---------------------------------------------------------------------- #
 
 # ----------------------------- REQUISITOS ----------------------------- #
 ## Removendo travas eventuais do apt ##
-sudo rm /var/lib/dpkg/lock-frontend
-sudo rm /var/cache/apt/archives/lock
+test -f /var/lib/apt/lists/lock && sudo rm -rf /var/lib/apt/lists/lock
+test -f /var/cache/apt/archives/lock && sudo rm -rf /var/cache/apt/archives/lock
+test -f /var/lib/dpkg/lock && sudo rm -rf /var/lib/dpkg/lock
+test -f /var/lib/dpkg/lock-frontend && sudo rm -rf /var/lib/dpkg/lock-frontend
 
 ## Adicionando/Confirmando arquitetura de 32 bits ##
 sudo dpkg --add-architecture i386
@@ -65,26 +40,60 @@ sudo apt-add-repository "deb $URL_PPA_WINE bionic main"
 ## Atualizando o repositório depois da adição de novos repositórios ##
 sudo apt update -y
 
+# criando a pasta de "~/Downloads/programas" apenas caso não exista
+[[ ! -d "$DIRETORIO_DOWNLOADS" ]] && mkdir "$DIRETORIO_DOWNLOADS"
+
 ## Download e instalaçao de programas externos ##
-mkdir "$DIRETORIO_DOWNLOADS"
 wget -c "$URL_GOOGLE_CHROME"       -P "$DIRETORIO_DOWNLOADS"
 wget -c "$URL_SIMPLE_NOTE"         -P "$DIRETORIO_DOWNLOADS"
 wget -c "$URL_4K_VIDEO_DOWNLOADER" -P "$DIRETORIO_DOWNLOADS"
 wget -c "$URL_INSYNC"              -P "$DIRETORIO_DOWNLOADS"
 
 ## Instalando pacotes .deb baixados na sessão anterior ##
-sudo dpkg -i $DIRETORIO_DOWNLOADS/*.deb
-
-# Instalar programas no apt
-for nome_do_programa in ${PROGRAMAS_PARA_INSTALAR[@]}; do
-  if ! dpkg -l | grep -q $nome_do_programa; then # Só instala se já não estiver instalado
-    apt install "$nome_do_programa" -y
-  else
-    echo "[INSTALADO] - $nome_do_programa"
-  fi
+for nome_do_programa in ${DIRETORIO_DOWNLOADS}/*.deb; do
+  sudo gdebi --non-interactive "$nome_do_programa"
 done
 
-sudo apt install --install-recommends winehq-stable wine-stable wine-stable-i386 wine-stable-amd64 -y
+# removendo os arquivos .deb do diretório de downloads, uma vez que já foram instalados e não precisa mais.
+rm -rf ${DIRETORIO_DOWNLOADS}/*.deb
+
+# Instalar programas no apt
+sudo apt install -y \
+  gdebi-core \
+  mint-meta-codecs \
+  winff \
+  guvcview \
+  virtualbox \
+  flameshot \
+  nemo-dropbox \
+  steam-installer \
+  steam-devices \
+  steam:i386 \
+  ratbagd \
+  piper \
+  lutris \
+  libvulkan1 \
+  libvulkan1:i386 \
+  libgnutls30:i386 \
+  libldap-2.4-2:i386 \
+  libgpg-error0:i386 \
+  libxml2:i386 \
+  libasound2-plugins:i386 \
+  libsdl2-2.0-0:i386 \
+  libfreetype6:i386 \
+  libdbus-1-3:i386 \
+  libsqlite3-0:i386
+
+  # instalando snap
+  sudo rm -rf /etc/apt/preferences.d/nosnap.pref
+  sudo apt update && sudo apt install -y snapd
+
+#  instalando o Wine
+sudo apt install -y --install-recommends \
+  winehq-stable \
+  wine-stable \
+  wine-stable-i386 \
+  wine-stable-amd64
 
 ## Instalando pacotes Flatpak ##
 flatpak install flathub com.obsproject.Studio -y

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# Linux-Mint-19.x-PosInstall
+# Linux Mint 20.x - PostInstall
+  ![](https://img.shields.io/badge/-Linux-000000.svg?style=for-the-badge&logo=Linux&logoColor=white)
+  ![](https://img.shields.io/badge/-Mint_20.04-004D40?style=for-the-badge&logo=linux-mint&logoColor=white)
+  
+# Descrição
 Shell Script de pós instalação do Linux Mint 19.x para utilização pessoal.
+
+### Alguns dos pacotes instalados:
+- Google Chrome
+- Insync
+- Wine
+- Simple Note
+- 4k Video Downloader
+- Virtualbox
+- snap
+- spotify
+- slack
+- skype
+
+## Contributors ✨
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/Diolinux"><img src="https://avatars2.githubusercontent.com/u/13944967?&v=4" width="100px;" alt=""/><br /><sub><b>Diolinux</b></sub></a><br />
+    </td>
+    <td align="center"><a href="https://github.com/mateusmuller"><img src="https://avatars2.githubusercontent.com/u/13832410?v=4" width="100px;" alt=""/><br /><sub><b>Mateus Muller</b></sub>
+     </td>
+     <td align="center"><a href="https://github.com/frankjuniorr"><img src="https://avatars2.githubusercontent.com/u/1384844?&v=4" width="100px;" alt=""/><br /><sub><b>Frank Junior</b></sub>
+     </td>
+  </tr>
+</table>
+
+## LICENSE
+
+[MIT](LICENSE)


### PR DESCRIPTION
### Observação:
Testado no Linux Mint 20.04

### Modificações
- Melhorado as validações de arquivo de lock do apt.
- Atualizado a URL do insync
- Adicionado algumas validações
- A validação pra saber se algum pacote já estava instalado no array de pacotes, funciona pra uns e não pra outros (`snap` era um dos que não tava validando realmente). Com isso, corrigi a instalação do `snap` (que de fato tinha um detalhe a mais) e acabei removendo o loop e a validação, já que o próprio `apt` desconsidera caso algum pacote da lista já esteja instalado.
- Melhorado a instalação dos pacotes .deb que são baixados pra `${HOME}/Downloads/programas` utilizando o `gdebi`. Ele melhora porque o gdebi resolve todas as dependências.
- Removido os pacotes .deb baixados, depois da instalação.
- Melhorado o README